### PR TITLE
✨ [Feature] chip 컴포넌트 리팩토링 & 모임 chip 구현

### DIFF
--- a/src/components/chip/Chip.stories.tsx
+++ b/src/components/chip/Chip.stories.tsx
@@ -29,7 +29,7 @@ export const RoundedLight: Story = {
 export const SquareOutlined: Story = {
   args: {
     text: '오프라인',
-    variant: 'square-light',
+    variant: 'square-outlined',
   },
 };
 
@@ -54,13 +54,13 @@ export const AllStates: Story = {
       <div className="flex gap-2">
         <Chip text="모집중" variant="rounded-filled" />
         <Chip text="1월 7일" variant="rounded-light" />
-        <Chip text="오프라인" variant="square-light" />
+        <Chip text="오프라인" variant="square-outlined" />
         <Chip text="마감" variant="square-filled" />
       </div>
       <div className="flex gap-2">
         <Chip text="자유책" variant="rounded-filled" isPast={true} />
         <Chip text="1월 7일" variant="rounded-light" isPast={true} />
-        <Chip text="오프라인" variant="square-light" isPast={true} />
+        <Chip text="오프라인" variant="square-outlined" isPast={true} />
         <Chip text="마감" variant="square-filled" isPast={true} />
       </div>
     </div>

--- a/src/components/chip/Chip.stories.tsx
+++ b/src/components/chip/Chip.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import Chip from './Chip';
 
 const meta = {
-  title: 'Components/Chip',
+  title: 'Components/Chip/Base',
   component: Chip,
   parameters: {
     layout: 'centered',

--- a/src/components/chip/Chip.test.tsx
+++ b/src/components/chip/Chip.test.tsx
@@ -2,7 +2,7 @@ import Chip from '@/components/chip/Chip';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 
-describe('TextChip', () => {
+describe('Chip', () => {
   it('텍스트가 올바르게 렌더링되어야 한다', () => {
     render(<Chip text="테스트" />);
     const chip = screen.getByText('테스트');

--- a/src/components/chip/Chip.tsx
+++ b/src/components/chip/Chip.tsx
@@ -1,11 +1,13 @@
 import { twMerge } from 'tailwind-merge';
 
 const CHIP_VARIANTS = {
-  'rounded-filled': 'rounded-full bg-green-light-02 text-green-dark-01',
-  'rounded-light': 'rounded-full bg-green-normal-01 text-gray-white',
-  'square-light':
-    'rounded border border-gray-normal-02 bg-gray-light-01 text-gray-dark-01',
-  'square-filled': 'rounded bg-green-dark-01 text-gray-dark-01',
+  'rounded-filled':
+    'rounded-full bg-green-light-02 text-green-dark-01 font-semibold',
+  'rounded-light':
+    'rounded-full bg-green-normal-01 text-gray-white font-semibold',
+  'square-outlined':
+    'rounded-md border border-green-normal-01 bg-gray-white text-green-normal-01',
+  'square-filled': 'rounded-md bg-green-normal-01 text-gray-white px-2',
 } as const;
 
 type ChipVariant = keyof typeof CHIP_VARIANTS;
@@ -24,7 +26,7 @@ function Chip({
   className,
 }: ChipProps) {
   const baseStyles =
-    'inline-flex items-center justify-center px-2.5 py-1 text-sm font-semibold';
+    'inline-flex items-center justify-center px-2.5 py-1 text-sm font-medium';
 
   const combinedClassName = twMerge(
     baseStyles,

--- a/src/components/chip/club-chip/ClubChip.stories.tsx
+++ b/src/components/chip/club-chip/ClubChip.stories.tsx
@@ -14,28 +14,24 @@ type Story = StoryObj<typeof ClubChip>;
 
 export const Completed: Story = {
   args: {
-    text: '참여완료',
     variant: 'completed',
   },
 };
 
 export const Scheduled: Story = {
   args: {
-    text: '참여예정',
     variant: 'scheduled',
   },
 };
 
 export const Pending: Story = {
   args: {
-    text: '개설대기',
     variant: 'pending',
   },
 };
 
 export const Confirmed: Story = {
   args: {
-    text: '개설확정',
     variant: 'confirmed',
   },
 };
@@ -43,10 +39,10 @@ export const Confirmed: Story = {
 export const AllStates: Story = {
   render: () => (
     <div className="flex gap-2">
-      <ClubChip text="참여완료" variant="completed" />
-      <ClubChip text="참여예정" variant="scheduled" />
-      <ClubChip text="개설대기" variant="pending" />
-      <ClubChip text="개설확정" variant="confirmed" />
+      <ClubChip variant="completed" />
+      <ClubChip variant="scheduled" />
+      <ClubChip variant="pending" />
+      <ClubChip variant="confirmed" />
     </div>
   ),
 };

--- a/src/components/chip/club-chip/ClubChip.stories.tsx
+++ b/src/components/chip/club-chip/ClubChip.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ClubChip from './ClubChip';
+
+const meta = {
+  title: 'Components/ClubChip',
+  component: ClubChip,
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof ClubChip>;
+
+export default meta;
+type Story = StoryObj<typeof ClubChip>;
+
+export const Completed: Story = {
+  args: {
+    text: '참여완료',
+    variant: 'completed',
+  },
+};
+
+export const Scheduled: Story = {
+  args: {
+    text: '참여예정',
+    variant: 'scheduled',
+  },
+};
+
+export const Pending: Story = {
+  args: {
+    text: '개설대기',
+    variant: 'pending',
+  },
+};
+
+export const Confirmed: Story = {
+  args: {
+    text: '개설확정',
+    variant: 'confirmed',
+  },
+};
+
+export const AllStates: Story = {
+  render: () => (
+    <div className="flex gap-2">
+      <ClubChip text="참여완료" variant="completed" />
+      <ClubChip text="참여예정" variant="scheduled" />
+      <ClubChip text="개설대기" variant="pending" />
+      <ClubChip text="개설확정" variant="confirmed" />
+    </div>
+  ),
+};

--- a/src/components/chip/club-chip/ClubChip.stories.tsx
+++ b/src/components/chip/club-chip/ClubChip.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import ClubChip from './ClubChip';
 
 const meta = {
-  title: 'Components/ClubChip',
+  title: 'Components/Chip/ClubChip',
   component: ClubChip,
   parameters: {
     layout: 'centered',

--- a/src/components/chip/club-chip/ClubChip.test.tsx
+++ b/src/components/chip/club-chip/ClubChip.test.tsx
@@ -1,0 +1,31 @@
+import ClubChip from './ClubChip';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+describe('ClubChip', () => {
+  it('텍스트가 올바르게 렌더링되어야 한다', () => {
+    render(<ClubChip text="참여완료" variant="completed" />);
+    expect(screen.getByText('참여완료')).toBeInTheDocument();
+  });
+
+  it('모든 variant가 올바르게 렌더링되어야 한다', () => {
+    const { rerender } = render(<ClubChip text="테스트" variant="completed" />);
+    expect(screen.getByText('테스트')).toBeInTheDocument();
+
+    rerender(<ClubChip text="테스트" variant="scheduled" />);
+    expect(screen.getByText('테스트')).toBeInTheDocument();
+
+    rerender(<ClubChip text="테스트" variant="pending" />);
+    expect(screen.getByText('테스트')).toBeInTheDocument();
+
+    rerender(<ClubChip text="테스트" variant="confirmed" />);
+    expect(screen.getByText('테스트')).toBeInTheDocument();
+  });
+
+  it('className prop으로 스타일을 오버라이드할 수 있어야 한다', () => {
+    render(
+      <ClubChip text="테스트" variant="completed" className="custom-class" />,
+    );
+    expect(screen.getByText('테스트')).toHaveClass('custom-class');
+  });
+});

--- a/src/components/chip/club-chip/ClubChip.test.tsx
+++ b/src/components/chip/club-chip/ClubChip.test.tsx
@@ -3,29 +3,27 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 
 describe('ClubChip', () => {
-  it('텍스트가 올바르게 렌더링되어야 한다', () => {
-    render(<ClubChip text="참여완료" variant="completed" />);
+  it('variant에 따라 올바른 텍스트가 렌더링되어야 한다', () => {
+    render(<ClubChip variant="completed" />);
     expect(screen.getByText('참여완료')).toBeInTheDocument();
   });
 
   it('모든 variant가 올바르게 렌더링되어야 한다', () => {
-    const { rerender } = render(<ClubChip text="테스트" variant="completed" />);
-    expect(screen.getByText('테스트')).toBeInTheDocument();
+    const { rerender } = render(<ClubChip variant="completed" />);
+    expect(screen.getByText('참여완료')).toBeInTheDocument();
 
-    rerender(<ClubChip text="테스트" variant="scheduled" />);
-    expect(screen.getByText('테스트')).toBeInTheDocument();
+    rerender(<ClubChip variant="scheduled" />);
+    expect(screen.getByText('참여예정')).toBeInTheDocument();
 
-    rerender(<ClubChip text="테스트" variant="pending" />);
-    expect(screen.getByText('테스트')).toBeInTheDocument();
+    rerender(<ClubChip variant="pending" />);
+    expect(screen.getByText('개설대기')).toBeInTheDocument();
 
-    rerender(<ClubChip text="테스트" variant="confirmed" />);
-    expect(screen.getByText('테스트')).toBeInTheDocument();
+    rerender(<ClubChip variant="confirmed" />);
+    expect(screen.getByText('개설확정')).toBeInTheDocument();
   });
 
   it('className prop으로 스타일을 오버라이드할 수 있어야 한다', () => {
-    render(
-      <ClubChip text="테스트" variant="completed" className="custom-class" />,
-    );
-    expect(screen.getByText('테스트')).toHaveClass('custom-class');
+    render(<ClubChip variant="completed" className="custom-class" />);
+    expect(screen.getByText('참여완료')).toHaveClass('custom-class');
   });
 });

--- a/src/components/chip/club-chip/ClubChip.tsx
+++ b/src/components/chip/club-chip/ClubChip.tsx
@@ -3,13 +3,19 @@ import { twMerge } from 'tailwind-merge';
 
 type ClubChipVariant = 'completed' | 'scheduled' | 'pending' | 'confirmed';
 
+const CLUB_CHIP_TEXT = {
+  completed: '참여완료',
+  scheduled: '참여예정',
+  pending: '개설대기',
+  confirmed: '개설확정',
+} as const;
+
 interface ClubChipProps {
-  text: string;
   variant: ClubChipVariant;
   className?: string;
 }
 
-function ClubChip({ text, variant, className }: ClubChipProps) {
+function ClubChip({ variant, className }: ClubChipProps) {
   const getChipVariant = () => {
     switch (variant) {
       case 'completed':
@@ -38,7 +44,7 @@ function ClubChip({ text, variant, className }: ClubChipProps) {
 
   return (
     <Chip
-      text={text}
+      text={CLUB_CHIP_TEXT[variant]}
       variant={getChipVariant()}
       className={twMerge(getCustomClassName(), className)}
     />

--- a/src/components/chip/club-chip/ClubChip.tsx
+++ b/src/components/chip/club-chip/ClubChip.tsx
@@ -1,0 +1,48 @@
+import Chip from '../Chip';
+import { twMerge } from 'tailwind-merge';
+
+type ClubChipVariant = 'completed' | 'scheduled' | 'pending' | 'confirmed';
+
+interface ClubChipProps {
+  text: string;
+  variant: ClubChipVariant;
+  className?: string;
+}
+
+function ClubChip({ text, variant, className }: ClubChipProps) {
+  const getChipVariant = () => {
+    switch (variant) {
+      case 'completed':
+        return 'square-filled';
+      case 'scheduled':
+        return 'square-filled';
+      case 'pending':
+        return 'square-outlined';
+      case 'confirmed':
+        return 'square-filled';
+    }
+  };
+
+  const getCustomClassName = () => {
+    switch (variant) {
+      case 'completed':
+        return 'bg-gray-normal-01 text-gray-dark-02';
+      case 'scheduled':
+        return 'bg-green-normal-01 text-gray-white';
+      case 'pending':
+        return 'border-blue-normal-01 text-blue-normal-01';
+      case 'confirmed':
+        return 'bg-blue-normal-01 text-gray-white';
+    }
+  };
+
+  return (
+    <Chip
+      text={text}
+      variant={getChipVariant()}
+      className={twMerge(getCustomClassName(), className)}
+    />
+  );
+}
+
+export default ClubChip;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -37,6 +37,9 @@ const config: Config = {
           'dark-03': '#004c41',
           darker: '#003b33',
         },
+        blue: {
+          'normal-01': '#007AFF',
+        },
       },
     },
   },


### PR DESCRIPTION
<!--
1. 제목은 50자 이내
2. 장황하게 설명하지 않고 간단하게 기술
3. 과거 시제 사용 X
4. 명사형 어미 사용

* 제목양식
:emoji:[태그] 제목 #이슈번호
태그 첫 글자는 대문자로 작성
예시) ✨[Feat] 로그인 기능 구현 #32

* 제목 태그 종류
✨[Feat] 새로운 기능 추가
🐛[Fix] 버그 수정
📝[Docs] 문서 수정
🎨[Style] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
💄[Design] CSS 등 사용자 UI 디자인 변경
♻️[Refactor] 코드 리팩토링
✅[Test] 테스트 코드, 리팩토링 테스트 코드 추가
📦[Chore] 빌드 업무 수정, 패키지 매니저 수정
🚚[Rename] 파일 혹은 몰더명 수정하거나 옮기는 작업만 한 경우
🔥[Remove] 파일을 삭제하는 작업만 한 경우
💬[Comment] 필요한 주석 추가 및 변경


* 작성 후 이슈, 라벨, 마일스톤 등 연결해주세요.
* Assignees : 작업자
-->

## #️⃣연관된 이슈

> ex) #126 , #126 

## 📝작업 내용

>  chip 컴포넌트 리팩토링

마이페이지 쪽에서 chip 디자인이 몇 개 새롭게 추가되었는데, 전체 chip 컴포넌트를 이에 맞게 바꿀지 고민하다가 나중에 교환쪽에서도 새로운 chip이 나오게 되면 varint를 수정하고 사용된 chip들을 다 변경하기가 번거로울 것 같아서 chip을 리팩토링 하고 마이 페이지에서 쓰는 chip의 경우 새롭게 chip 폴더 내부에 `ClubChip`으로 구현했습니다.


### 미리보기, 사용방법 및 결과물

chip 컴포넌트는 4개의 varint로 모양에 따라 기본 틀만 담당해줍니다. (밑에 회색부분은 지난 모임인지 아닌지 여부에 따라 색상 바뀌는 부분)

<img width="498" alt="image" src="https://github.com/user-attachments/assets/276ae54a-0806-4a9c-9175-7db67dd0d715">

해당 chip 컴포넌트를 베이스로 모임에서 사용되는 chip들을 따로 만들어 두었습니다.

<img width="508" alt="image" src="https://github.com/user-attachments/assets/990601ea-b6a8-4e88-8f08-ab1db14828fe">

기본 틀은 chip컴포넌트에서 받아오고 varint (참여 완료 등..)에 따라 모양을 구체화하는 식으로 만들었습니다.

실제 사용 코드 예시

<img width="456" alt="image" src="https://github.com/user-attachments/assets/e5862845-02fc-4ede-820e-adbf4b085b18">




<!-- 미리보기 파일 첨부와 함께 사용 방법 작성. 이미지, 동영상 등 작업 내용을 확인할 수 있는 파일 첨부 -->

<!-- ## 💬리뷰 요구사항(선택) - 보류(코드 리뷰를 진행한다면...)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

### 기타 참고사항

<!-- 필요한 경우 작성해주세요 -->
