### PR TITLE
♻️ [Refactor] checkLoginStatus를 로그인 페이지에서 확인 #176

### DIFF
--- a/src/components/header/HeaderBar.tsx
+++ b/src/components/header/HeaderBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import NavButton from './NavButton';
 import { NAV_ITEMS } from '@/constants/navigation';
 import { usePathname, useRouter } from 'next/navigation';
@@ -10,12 +10,8 @@ import { logout } from '@/features/auth/api/auth';
 
 function HeaderBar() {
   const pathname = usePathname();
-  const { isLoggedIn, user, checkLoginStatus } = useAuthStore();
+  const { isLoggedIn, user } = useAuthStore();
   const router = useRouter();
-
-  useEffect(() => {
-    checkLoginStatus();
-  }, [checkLoginStatus]);
 
   const handleDropDownChange = async (value: string | undefined) => {
     if (value === 'LOGOUT') {

--- a/src/features/auth/container/login-form/LoginForm.tsx
+++ b/src/features/auth/container/login-form/LoginForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import Link from 'next/link';
@@ -8,12 +8,14 @@ import Link from 'next/link';
 import Button from '@/components/button/Button';
 import FormField from '@/features/auth/components/form-field/FormField';
 import { useLoginSubmit } from '@/features/auth/hooks/useLoginSubmit';
+import { useAuthStore } from '@/store/authStore';
 import {
   loginFormSchema,
   type LoginFormData,
 } from '@/features/auth/types/loginFormSchema';
 
 export default function LoginForm() {
+  const { checkLoginStatus } = useAuthStore();
   const {
     register,
     handleSubmit,
@@ -24,6 +26,10 @@ export default function LoginForm() {
     resolver: zodResolver(loginFormSchema),
     mode: 'onChange',
   });
+
+  useEffect(() => {
+    checkLoginStatus();
+  }, [checkLoginStatus]);
 
   const onSubmit = useLoginSubmit(setError, reset);
 


### PR DESCRIPTION
<!--
1. 제목은 50자 이내
2. 장황하게 설명하지 않고 간단하게 기술
3. 과거 시제 사용 X
4. 명사형 어미 사용

* 제목양식
:emoji:[태그] 제목 #이슈번호
태그 첫 글자는 대문자로 작성
예시) ✨[Feat] 로그인 기능 구현 #32

* 제목 태그 종류
✨[Feat] 새로운 기능 추가
🐛[Fix] 버그 수정
📝[Docs] 문서 수정
🎨[Style] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
💄[Design] CSS 등 사용자 UI 디자인 변경
♻️[Refactor] 코드 리팩토링
✅[Test] 테스트 코드, 리팩토링 테스트 코드 추가
📦[Chore] 빌드 업무 수정, 패키지 매니저 수정
🚚[Rename] 파일 혹은 몰더명 수정하거나 옮기는 작업만 한 경우
🔥[Remove] 파일을 삭제하는 작업만 한 경우
💬[Comment] 필요한 주석 추가 및 변경


* 작성 후 이슈, 라벨, 마일스톤 등 연결해주세요.
* Assignees : 작업자
-->

## #️⃣연관된 이슈

> #176

## 📝작업 내용

## Header Bar 로그인 상태 확인 방식 리팩토링

### 기존 방식
- **로그인 상태 확인 위치:** Header Bar에서 `checkLoginStatus` 호출.
- **문제점:**
  - [프로필 버튼]이 [로그인 버튼]으로 변경되려면 페이지 새로고침 해야 했음.

### 변경된 방식
1. **엑세스 토큰 만료**:
   - 브라우저 **쿠키에서 토큰 제거**.
2. **사용자가 토큰이 필요한 페이지 접근**:
   - 예: 찜하기 페이지.
   - **미들웨어**에서 토큰 유무 확인 후, 토큰이 없으면 **로그인 페이지로 리다이렉션**.
3. **로그인 페이지에서 로그인 상태 업데이트**:
   - `checkLoginStatus` 호출.
   - `isLoggedIn` 상태를 `false`로 변경.
4. **Header Bar 상태 업데이트**:
   - `isLoggedIn` 상태 변화를 감지.
   - [프로필 버튼] → [로그인 버튼]으로 변경.

### 리팩토링 결과
- **페이지 새로고침 없이** [프로필 버튼]이 [로그인 버튼]으로 변경.

