### PR TITLE
✨ [Feat] 채팅 카드 컴포넌트 UI 구현

### DIFF
--- a/src/components/badge/Badge.stories.tsx
+++ b/src/components/badge/Badge.stories.tsx
@@ -1,0 +1,67 @@
+import Badge from '@/components/badge/Badge';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Components/Badge',
+  component: Badge,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Badge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DefaultBadge: Story = {
+  args: {
+    count: 1,
+    size: 'md',
+    variant: 'default',
+  },
+};
+
+export const DefaultBadgeSizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Badge count={1} size="sm" />
+      <Badge count={1} size="md" />
+      <Badge count={1} size="lg" />
+    </div>
+  ),
+};
+
+export const DefaultBadgeNumbers: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Badge count={1} />
+      <Badge count={99} />
+      <Badge count={999} />
+      <Badge count={1000} />
+    </div>
+  ),
+};
+
+export const DotBadge: Story = {
+  args: {
+    variant: 'dot',
+    size: 'md',
+  },
+};
+
+export const DotBadgeSizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Badge variant="dot" size="sm" />
+      <Badge variant="dot" size="md" />
+      <Badge variant="dot" size="lg" />
+    </div>
+  ),
+};
+
+export const CustomStyle: Story = {
+  args: {
+    count: 5,
+    className: 'bg-blue-500',
+  },
+};

--- a/src/components/badge/Badge.test.tsx
+++ b/src/components/badge/Badge.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Badge from './Badge';
+
+describe('Badge', () => {
+  it('숫자가 1000 이상일 때 999+로 표시된다', () => {
+    render(<Badge count={1000} />);
+    expect(screen.getByText('999+')).toBeInTheDocument();
+  });
+
+  it('숫자가 1000 미만일 때 실제 숫자가 표시된다', () => {
+    render(<Badge count={999} />);
+    expect(screen.getByText('999')).toBeInTheDocument();
+  });
+
+  it('variant가 dot일 때는 숫자가 표시되지 않는다', () => {
+    const { container } = render(<Badge variant="dot" count={5} />);
+    expect(container.textContent).toBe('');
+  });
+});

--- a/src/components/badge/Badge.test.tsx
+++ b/src/components/badge/Badge.test.tsx
@@ -14,7 +14,7 @@ describe('Badge', () => {
   });
 
   it('variant가 dot일 때는 숫자가 표시되지 않는다', () => {
-    const { container } = render(<Badge variant="dot" count={5} />);
-    expect(container.textContent).toBe('');
+    render(<Badge variant="dot" count={5} />);
+    expect(screen.queryByText('5')).not.toBeInTheDocument();
   });
 });

--- a/src/components/badge/Badge.tsx
+++ b/src/components/badge/Badge.tsx
@@ -1,0 +1,58 @@
+import { twMerge } from 'tailwind-merge';
+
+interface BadgeProps extends React.HTMLAttributes<HTMLDivElement> {
+  count?: number;
+  size?: 'sm' | 'md' | 'lg';
+  variant?: 'default' | 'dot';
+}
+
+const sizeStyles = {
+  sm: 'h-[20px] min-w-[20px] px-1.5 text-[10px]',
+  md: 'h-[26px] min-w-[26px] px-2 text-xs',
+  lg: 'h-[32px] min-w-[32px] px-2.5 text-sm',
+} as const;
+
+const dotSizeStyles = {
+  sm: 'h-2 w-2',
+  md: 'h-2.5 w-2.5',
+  lg: 'h-3 w-3',
+} as const;
+
+// TODO: 추후 위치 정보(vertical, horizontal) 에 따라 뱃지 위치를 조정할 수 있도록 하는 기능이 필요할 수 있음
+function Badge({
+  count,
+  size = 'md',
+  variant = 'default',
+  className,
+  ...props
+}: BadgeProps) {
+  if (variant === 'dot') {
+    return (
+      <div
+        className={twMerge(
+          'rounded-full bg-red-normal',
+          dotSizeStyles[size],
+          className,
+        )}
+        {...props}
+      />
+    );
+  }
+
+  const displayCount = count && count >= 1000 ? '999+' : count;
+
+  return (
+    <div
+      className={twMerge(
+        'flex items-center justify-center rounded-full bg-red-normal font-semibold text-gray-white',
+        sizeStyles[size],
+        className,
+      )}
+      {...props}
+    >
+      {displayCount}
+    </div>
+  );
+}
+
+export default Badge;

--- a/src/components/chat-card/ChatCard.stories.tsx
+++ b/src/components/chat-card/ChatCard.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ChatCard from './ChatCard';
+
+const meta = {
+  title: 'Components/ChatCard/Atoms',
+  component: ChatCard,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ChatCard>;
+
+export default meta;
+type Story = StoryObj<typeof ChatCard>;
+
+export const Box: Story = {
+  args: {
+    children: '기본 박스',
+  },
+  render: () => (
+    <div className="flex gap-4">
+      <ChatCard.Box>기본 박스</ChatCard.Box>
+      <ChatCard.Box isHost>호스트 박스</ChatCard.Box>
+    </div>
+  ),
+};
+
+export const Title: Story = {
+  args: {
+    children: '채팅방 제목',
+  },
+  render: () => <ChatCard.Title>채팅방 제목</ChatCard.Title>,
+};
+
+export const Image: Story = {
+  args: {},
+  render: () => (
+    <div className="flex gap-4">
+      <ChatCard.Image url="https://picsum.photos/200" alt="채팅방 이미지" />
+      <ChatCard.Image
+        url="https://picsum.photos/200"
+        alt="호스트 채팅방 이미지"
+        isHost
+      />
+    </div>
+  ),
+};
+
+export const Location: Story = {
+  args: {
+    children: '서울 강남구',
+  },
+  render: () => <ChatCard.Location>서울 강남구</ChatCard.Location>,
+};
+
+export const DateTime: Story = {
+  args: {
+    children: '2024.03.15 토요일 15:00',
+  },
+  render: () => <ChatCard.DateTime>2024.03.15 토요일 15:00</ChatCard.DateTime>,
+};
+
+export const LastMessage: Story = {
+  args: {
+    children: '안녕하세요! 반갑습니다.',
+  },
+  render: () => (
+    <ChatCard.LastMessage>안녕하세요! 반갑습니다.</ChatCard.LastMessage>
+  ),
+};
+
+export const LastMessageTime: Story = {
+  args: {
+    children: '1시간 전',
+  },
+  render: () => <ChatCard.LastMessageTime>1시간 전</ChatCard.LastMessageTime>,
+};

--- a/src/components/chat-card/ChatCard.stories.tsx
+++ b/src/components/chat-card/ChatCard.stories.tsx
@@ -14,64 +14,39 @@ export default meta;
 type Story = StoryObj<typeof ChatCard>;
 
 export const Box: Story = {
-  args: {
-    children: '기본 박스',
-  },
   render: () => (
-    <div className="flex gap-4">
-      <ChatCard.Box>기본 박스</ChatCard.Box>
-      <ChatCard.Box isHost>호스트 박스</ChatCard.Box>
-    </div>
+    <ChatCard.Box isHost>
+      <p>ChatCard Box Content</p>
+    </ChatCard.Box>
   ),
 };
 
 export const Title: Story = {
-  args: {
-    children: '채팅방 제목',
-  },
   render: () => <ChatCard.Title>채팅방 제목</ChatCard.Title>,
 };
 
 export const Image: Story = {
-  args: {},
   render: () => (
-    <div className="flex gap-4">
-      <ChatCard.Image url="https://picsum.photos/200" alt="채팅방 이미지" />
-      <ChatCard.Image
-        url="https://picsum.photos/200"
-        alt="호스트 채팅방 이미지"
-        isHost
-      />
-    </div>
+    <ChatCard.Image
+      url="https://picsum.photos/200"
+      isHost={true}
+      alt="채팅방 이미지"
+    />
   ),
 };
 
 export const Location: Story = {
-  args: {
-    children: '서울 강남구',
-  },
-  render: () => <ChatCard.Location>서울 강남구</ChatCard.Location>,
+  render: () => <ChatCard.Location>서울특별시 강남구</ChatCard.Location>,
 };
 
 export const DateTime: Story = {
-  args: {
-    children: '2024.03.15 토요일 15:00',
-  },
-  render: () => <ChatCard.DateTime>2024.03.15 토요일 15:00</ChatCard.DateTime>,
+  render: () => <ChatCard.DateTime>2024.03.15 (금) 19:00</ChatCard.DateTime>,
 };
 
 export const LastMessage: Story = {
-  args: {
-    children: '안녕하세요! 반갑습니다.',
-  },
-  render: () => (
-    <ChatCard.LastMessage>안녕하세요! 반갑습니다.</ChatCard.LastMessage>
-  ),
+  render: () => <ChatCard.LastMessage>반갑습니다~!</ChatCard.LastMessage>,
 };
 
 export const LastMessageTime: Story = {
-  args: {
-    children: '1시간 전',
-  },
-  render: () => <ChatCard.LastMessageTime>1시간 전</ChatCard.LastMessageTime>,
+  render: () => <ChatCard.LastMessageTime>10:29</ChatCard.LastMessageTime>,
 };

--- a/src/components/chat-card/ChatCard.tsx
+++ b/src/components/chat-card/ChatCard.tsx
@@ -54,22 +54,23 @@ function ChatCardImage({
   ...props
 }: ChatCardImageProps) {
   return (
-    <div
-      className={twMerge(
-        'relative h-[50px] w-[50px] overflow-hidden rounded-[20px] md:h-[100px] md:w-[100px]',
-        className,
-      )}
-      {...props}
-    >
-      <Image
-        src={url || defaultBookClub}
-        alt={alt}
-        fill
-        className="object-cover"
-      />
+    <div className="relative" {...props}>
+      <div
+        className={twMerge(
+          'relative h-[50px] w-[50px] overflow-hidden rounded-[10px] md:h-[100px] md:w-[100px] md:rounded-[20px]',
+          className,
+        )}
+      >
+        <Image
+          src={url || defaultBookClub}
+          alt={alt}
+          fill
+          className="object-cover"
+        />
+      </div>
       {isHost && (
-        <div className="absolute -bottom-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full border-2 border-gray-normal-01 bg-green-normal-01">
-          <HostIcon />
+        <div className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full border-2 border-gray-normal-01 bg-green-normal-01 md:-right-2 md:h-6 md:w-6">
+          <HostIcon width={8} height={8} className="md:h-[13px] md:w-[13px]" />
         </div>
       )}
     </div>

--- a/src/components/chat-card/ChatCard.tsx
+++ b/src/components/chat-card/ChatCard.tsx
@@ -1,0 +1,150 @@
+import { twMerge } from 'tailwind-merge';
+import Image from 'next/image';
+import {
+  ChatCardProps,
+  ChatCardBoxProps,
+  ChatCardTitleProps,
+  ChatCardImageProps,
+  ChatCardLocationProps,
+  ChatCardDateTimeProps,
+  ChatCardLastMessageProps,
+  ChatCardLastMessageTimeProps,
+} from './types';
+import { LocationIcon } from '../../../public/icons';
+
+function ChatCardBox({ children, className, ...props }: ChatCardBoxProps) {
+  return (
+    <div
+      className={twMerge(
+        'relative flex min-h-[74px] w-[336px] flex-col rounded-[20px] border-2 border-gray-normal-01 p-3 md:min-h-[155px] md:w-full md:p-6',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+function ChatCardTitle({ children, className, ...props }: ChatCardTitleProps) {
+  return (
+    <h3
+      className={twMerge('font-semibold text-gray-black md:text-xl', className)}
+      {...props}
+    >
+      {children}
+    </h3>
+  );
+}
+
+function ChatCardImage({
+  url,
+  alt = '채팅방 이미지',
+  className,
+  ...props
+}: ChatCardImageProps) {
+  return (
+    <div
+      className={twMerge(
+        'relative h-[50px] w-[50px] overflow-hidden rounded-[20px] md:h-[100px] md:w-[100px]',
+        className,
+      )}
+      {...props}
+    >
+      <Image src={url} alt={alt} fill className="object-cover" />
+    </div>
+  );
+}
+
+function ChatCardLocation({
+  children,
+  className,
+  textClassName,
+  ...props
+}: ChatCardLocationProps) {
+  return (
+    <div className={twMerge('flex items-center', className)} {...props}>
+      <LocationIcon />
+      <span
+        className={twMerge(
+          'text-sm font-semibold text-gray-dark-03',
+          textClassName,
+        )}
+      >
+        {children}
+      </span>
+    </div>
+  );
+}
+
+function ChatCardDateTime({
+  children,
+  className,
+  ...props
+}: ChatCardDateTimeProps) {
+  return (
+    <span
+      className={twMerge('text-sm font-medium text-gray-dark-03', className)}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}
+
+function ChatCardLastMessage({
+  children,
+  className,
+  ...props
+}: ChatCardLastMessageProps) {
+  return (
+    <div
+      className={twMerge(
+        'text-sm font-medium text-gray-dark-01 md:text-base',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+function ChatCardLastMessageTime({
+  children,
+  className,
+  ...props
+}: ChatCardLastMessageTimeProps) {
+  return (
+    <span
+      className={twMerge(
+        'text-xs font-medium text-gray-dark-01 md:text-sm',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}
+
+function ChatCard({ children, className, ...props }: ChatCardProps) {
+  return (
+    <article
+      className={twMerge('relative flex flex-col', className)}
+      {...props}
+    >
+      {children}
+    </article>
+  );
+}
+
+ChatCard.Box = ChatCardBox;
+ChatCard.Title = ChatCardTitle;
+ChatCard.Image = ChatCardImage;
+ChatCard.Location = ChatCardLocation;
+ChatCard.DateTime = ChatCardDateTime;
+ChatCard.LastMessage = ChatCardLastMessage;
+ChatCard.LastMessageTime = ChatCardLastMessageTime;
+
+export default ChatCard;

--- a/src/components/chat-card/ChatCard.tsx
+++ b/src/components/chat-card/ChatCard.tsx
@@ -12,6 +12,7 @@ import {
   ChatCardLastMessageTimeProps,
 } from './types';
 import { LocationIcon } from '../../../public/icons';
+import defaultBookClub from '../../../public/images/defaultBookClub.jpg';
 
 function ChatCardBox({
   children,
@@ -60,7 +61,12 @@ function ChatCardImage({
       )}
       {...props}
     >
-      <Image src={url} alt={alt} fill className="object-cover" />
+      <Image
+        src={url || defaultBookClub}
+        alt={alt}
+        fill
+        className="object-cover"
+      />
       {isHost && (
         <div className="absolute -bottom-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full border-2 border-gray-normal-01 bg-green-normal-01">
           <HostIcon />

--- a/src/components/chat-card/ChatCard.tsx
+++ b/src/components/chat-card/ChatCard.tsx
@@ -10,6 +10,8 @@ import {
   ChatCardLastMessageProps,
   ChatCardLastMessageTimeProps,
   ChatCardComponentProps,
+  ChatRoomHeaderProps,
+  BookClubProps,
 } from './types';
 import { LocationIcon } from '../../../public/icons';
 import defaultBookClub from '../../../public/images/defaultBookClub.jpg';
@@ -92,7 +94,7 @@ function ChatCardLocation({
       <LocationIcon />
       <span
         className={twMerge(
-          'text-sm font-semibold text-gray-dark-03',
+          'text-xs font-semibold text-gray-dark-03 md:text-sm',
           textClassName,
         )}
       >
@@ -109,7 +111,10 @@ function ChatCardDateTime({
 }: ChatCardDateTimeProps) {
   return (
     <span
-      className={twMerge('text-sm font-medium text-gray-dark-03', className)}
+      className={twMerge(
+        'text-xs font-medium text-gray-dark-03 md:text-sm',
+        className,
+      )}
       {...props}
     >
       {children}
@@ -166,7 +171,7 @@ function ChatCard({ variant, props }: ChatCardComponentProps) {
           lastMessageTime,
           unreadCount,
           className,
-        } = props;
+        } = props as BookClubProps;
 
         return (
           <ChatCardBox isHost={isHost} className={className}>
@@ -207,8 +212,26 @@ function ChatCard({ variant, props }: ChatCardComponentProps) {
         );
       }
 
-      case 'default':
-        return null; // 기본 케이스 처리
+      case 'chatRoomHeader': {
+        const { imageUrl, isHost, title, location, datetime, className } =
+          props as ChatRoomHeaderProps;
+
+        return (
+          <ChatCardBox isHost={isHost} className={className}>
+            <div className="flex w-full items-center gap-3 md:gap-6">
+              <ChatCardImage url={imageUrl} isHost={isHost} />
+
+              <div className="flex min-w-0 flex-1 flex-col">
+                <ChatCardTitle>{title}</ChatCardTitle>
+                <div className="flex min-w-0 items-center gap-1 md:gap-1.5">
+                  <ChatCardLocation>{location}</ChatCardLocation>
+                  <ChatCardDateTime>{datetime}</ChatCardDateTime>
+                </div>
+              </div>
+            </div>
+          </ChatCardBox>
+        );
+      }
 
       default:
         return null;

--- a/src/components/chat-card/ChatCard.tsx
+++ b/src/components/chat-card/ChatCard.tsx
@@ -12,6 +12,7 @@ import {
   ChatCardComponentProps,
   ChatRoomHeaderProps,
   BookClubProps,
+  ChatCardVariant,
 } from './types';
 import { LocationIcon } from '../../../public/icons';
 import defaultBookClub from '../../../public/images/defaultBookClub.jpg';
@@ -158,7 +159,10 @@ function ChatCardLastMessageTime({
   );
 }
 
-function ChatCard({ variant, props }: ChatCardComponentProps) {
+function ChatCard<T extends ChatCardVariant>({
+  variant,
+  props,
+}: ChatCardComponentProps<T>) {
   const renderContent = () => {
     switch (variant) {
       case 'bookClub': {

--- a/src/components/chat-card/ChatCard.tsx
+++ b/src/components/chat-card/ChatCard.tsx
@@ -1,5 +1,6 @@
 import { twMerge } from 'tailwind-merge';
 import Image from 'next/image';
+import { HostIcon } from '../../../public/icons';
 import {
   ChatCardProps,
   ChatCardBoxProps,
@@ -12,11 +13,18 @@ import {
 } from './types';
 import { LocationIcon } from '../../../public/icons';
 
-function ChatCardBox({ children, className, ...props }: ChatCardBoxProps) {
+function ChatCardBox({
+  children,
+  className,
+  isHost,
+  ...props
+}: ChatCardBoxProps) {
   return (
     <div
       className={twMerge(
-        'relative flex min-h-[74px] w-[336px] flex-col rounded-[20px] border-2 border-gray-normal-01 p-3 md:min-h-[155px] md:w-full md:p-6',
+        'relative flex min-h-[74px] w-[336px] flex-col rounded-[20px] border-2',
+        isHost ? 'border-green-normal-01' : 'border-gray-normal-01',
+        'p-3 md:min-h-[155px] md:w-full md:p-6',
         className,
       )}
       {...props}
@@ -40,6 +48,7 @@ function ChatCardTitle({ children, className, ...props }: ChatCardTitleProps) {
 function ChatCardImage({
   url,
   alt = '채팅방 이미지',
+  isHost,
   className,
   ...props
 }: ChatCardImageProps) {
@@ -52,6 +61,11 @@ function ChatCardImage({
       {...props}
     >
       <Image src={url} alt={alt} fill className="object-cover" />
+      {isHost && (
+        <div className="absolute -bottom-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full border-2 border-gray-normal-01 bg-green-normal-01">
+          <HostIcon />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/chat-card/ChatCard.tsx
+++ b/src/components/chat-card/ChatCard.tsx
@@ -2,7 +2,6 @@ import { twMerge } from 'tailwind-merge';
 import Image from 'next/image';
 import { HostIcon } from '../../../public/icons';
 import {
-  ChatCardProps,
   ChatCardBoxProps,
   ChatCardTitleProps,
   ChatCardImageProps,
@@ -10,9 +9,12 @@ import {
   ChatCardDateTimeProps,
   ChatCardLastMessageProps,
   ChatCardLastMessageTimeProps,
+  ChatCardComponentProps,
 } from './types';
 import { LocationIcon } from '../../../public/icons';
 import defaultBookClub from '../../../public/images/defaultBookClub.jpg';
+import ParticipantCounter from '../participant-counter/ParticipantCounter';
+import Badge from '../badge/Badge';
 
 function ChatCardBox({
   children,
@@ -139,7 +141,7 @@ function ChatCardLastMessageTime({
   return (
     <span
       className={twMerge(
-        'text-xs font-medium text-gray-dark-01 md:text-sm',
+        'text-xs font-medium text-gray-normal-03 md:text-sm',
         className,
       )}
       {...props}
@@ -149,15 +151,58 @@ function ChatCardLastMessageTime({
   );
 }
 
-function ChatCard({ children, className, ...props }: ChatCardProps) {
-  return (
-    <article
-      className={twMerge('relative flex flex-col', className)}
-      {...props}
-    >
-      {children}
-    </article>
-  );
+function ChatCard({ variant, props }: ChatCardComponentProps) {
+  const renderContent = () => {
+    switch (variant) {
+      case 'bookClub': {
+        const {
+          imageUrl,
+          isHost,
+          title,
+          currentParticipants,
+          lastMessage,
+          lastMessageTime,
+          unreadCount,
+          className,
+        } = props;
+
+        return (
+          <ChatCardBox isHost={isHost} className={className}>
+            <div className="flex items-center gap-3 md:gap-6">
+              <ChatCardImage url={imageUrl} isHost={isHost} />
+
+              <div className="flex flex-1 flex-col gap-[10px] md:gap-3">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-1">
+                    <ChatCardTitle>{title}</ChatCardTitle>
+                    <ParticipantCounter current={currentParticipants} />
+                  </div>
+                  {unreadCount && unreadCount > 0 && (
+                    <Badge count={unreadCount} size="md" />
+                  )}
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <ChatCardLastMessage>{lastMessage}</ChatCardLastMessage>
+                  <ChatCardLastMessageTime>
+                    {lastMessageTime}
+                  </ChatCardLastMessageTime>
+                </div>
+              </div>
+            </div>
+          </ChatCardBox>
+        );
+      }
+
+      case 'default':
+        return null; // 기본 케이스 처리
+
+      default:
+        return null;
+    }
+  };
+
+  return renderContent();
 }
 
 ChatCard.Box = ChatCardBox;

--- a/src/components/chat-card/ChatCard.tsx
+++ b/src/components/chat-card/ChatCard.tsx
@@ -23,6 +23,7 @@ function ChatCardBox({
   children,
   className,
   isHost,
+  onClick,
   ...props
 }: ChatCardBoxProps) {
   return (
@@ -30,8 +31,10 @@ function ChatCardBox({
       className={twMerge(
         'relative flex min-h-[74px] min-w-[336px] flex-col rounded-[20px] border-2 bg-gray-light-01 p-3 md:min-h-[155px] md:p-6',
         isHost ? 'border-green-normal-01' : 'border-gray-normal-01',
+        onClick && 'cursor-pointer',
         className,
       )}
+      onClick={onClick}
       {...props}
     >
       {children}
@@ -175,10 +178,11 @@ function ChatCard<T extends ChatCardVariant>({
           lastMessageTime,
           unreadCount,
           className,
+          onClick,
         } = props as BookClubProps;
 
         return (
-          <ChatCardBox isHost={isHost} className={className}>
+          <ChatCardBox isHost={isHost} className={className} onClick={onClick}>
             <div className="flex w-full items-center gap-3 md:gap-6">
               <ChatCardImage url={imageUrl} isHost={isHost} />
 
@@ -217,11 +221,18 @@ function ChatCard<T extends ChatCardVariant>({
       }
 
       case 'chatRoomHeader': {
-        const { imageUrl, isHost, title, location, datetime, className } =
-          props as ChatRoomHeaderProps;
+        const {
+          imageUrl,
+          isHost,
+          title,
+          location,
+          datetime,
+          className,
+          onClick,
+        } = props as ChatRoomHeaderProps;
 
         return (
-          <ChatCardBox isHost={isHost} className={className}>
+          <ChatCardBox isHost={isHost} className={className} onClick={onClick}>
             <div className="flex w-full items-center gap-3 md:gap-6">
               <ChatCardImage url={imageUrl} isHost={isHost} />
 

--- a/src/components/chat-card/ChatCard.tsx
+++ b/src/components/chat-card/ChatCard.tsx
@@ -25,9 +25,8 @@ function ChatCardBox({
   return (
     <div
       className={twMerge(
-        'relative flex min-h-[74px] w-[336px] flex-col rounded-[20px] border-2',
+        'relative flex min-h-[74px] min-w-[336px] flex-col rounded-[20px] border-2 bg-gray-light-01 p-3 md:min-h-[155px] md:p-6',
         isHost ? 'border-green-normal-01' : 'border-gray-normal-01',
-        'p-3 md:min-h-[155px] md:w-full md:p-6',
         className,
       )}
       {...props}
@@ -40,7 +39,10 @@ function ChatCardBox({
 function ChatCardTitle({ children, className, ...props }: ChatCardTitleProps) {
   return (
     <h3
-      className={twMerge('font-semibold text-gray-black md:text-xl', className)}
+      className={twMerge(
+        'truncate font-semibold text-gray-black md:text-xl',
+        className,
+      )}
       {...props}
     >
       {children}
@@ -123,7 +125,7 @@ function ChatCardLastMessage({
   return (
     <div
       className={twMerge(
-        'text-sm font-medium text-gray-dark-01 md:text-base',
+        'min-w-0 flex-1 truncate text-sm font-medium text-gray-dark-01 md:text-base',
         className,
       )}
       {...props}
@@ -141,7 +143,7 @@ function ChatCardLastMessageTime({
   return (
     <span
       className={twMerge(
-        'text-xs font-medium text-gray-normal-03 md:text-sm',
+        'shrink-0 text-xs font-medium text-gray-normal-03 md:text-sm',
         className,
       )}
       {...props}
@@ -168,21 +170,32 @@ function ChatCard({ variant, props }: ChatCardComponentProps) {
 
         return (
           <ChatCardBox isHost={isHost} className={className}>
-            <div className="flex items-center gap-3 md:gap-6">
+            <div className="flex w-full items-center gap-3 md:gap-6">
               <ChatCardImage url={imageUrl} isHost={isHost} />
 
-              <div className="flex flex-1 flex-col gap-[10px] md:gap-3">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-1">
+              <div className="flex min-w-0 flex-1 flex-col gap-[10px] md:gap-3">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex min-w-0 items-center gap-1">
                     <ChatCardTitle>{title}</ChatCardTitle>
                     <ParticipantCounter current={currentParticipants} />
                   </div>
                   {unreadCount && unreadCount > 0 && (
-                    <Badge count={unreadCount} size="md" />
+                    <>
+                      <Badge
+                        count={unreadCount}
+                        size="sm"
+                        className="md:hidden"
+                      />
+                      <Badge
+                        count={unreadCount}
+                        size="md"
+                        className="hidden md:flex"
+                      />
+                    </>
                   )}
                 </div>
 
-                <div className="flex items-center justify-between">
+                <div className="flex min-w-0 items-center justify-between gap-2">
                   <ChatCardLastMessage>{lastMessage}</ChatCardLastMessage>
                   <ChatCardLastMessageTime>
                     {lastMessageTime}

--- a/src/components/chat-card/VariantChatCard.stories.tsx
+++ b/src/components/chat-card/VariantChatCard.stories.tsx
@@ -34,8 +34,66 @@ const baseArgs = {
   },
 };
 
-// 모바일 버전
-export const Mobile: Story = {
+const chatRoomHeaderArgs = {
+  variant: 'chatRoomHeader' as const,
+  props: {
+    title: '을지로에서 만나는 독서 모임',
+    imageUrl: 'https://picsum.photos/200',
+    isHost: false,
+    location: '을지로 3가',
+    datetime: '12/14(토) 오전 10:00',
+  },
+};
+
+export const ChatRoomHeaderMobile: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[342px]">
+        <Story />
+      </div>
+    ),
+  ],
+  args: chatRoomHeaderArgs,
+};
+
+export const ChatRoomHeaderTablet: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'tablet',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[700px]">
+        <Story />
+      </div>
+    ),
+  ],
+  args: chatRoomHeaderArgs,
+};
+
+export const ChatRoomHeaderDesktop: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[1000px]">
+        <Story />
+      </div>
+    ),
+  ],
+  args: chatRoomHeaderArgs,
+};
+
+export const BookClubMobile: Story = {
   parameters: {
     viewport: {
       defaultViewport: 'mobile',
@@ -51,8 +109,7 @@ export const Mobile: Story = {
   args: baseArgs,
 };
 
-// 태블릿 버전
-export const Tablet: Story = {
+export const BookClubTablet: Story = {
   parameters: {
     viewport: {
       defaultViewport: 'tablet',
@@ -68,8 +125,7 @@ export const Tablet: Story = {
   args: baseArgs,
 };
 
-// 데스크톱 버전
-export const Desktop: Story = {
+export const BookClubDesktop: Story = {
   parameters: {
     viewport: {
       defaultViewport: 'desktop',

--- a/src/components/chat-card/VariantChatCard.stories.tsx
+++ b/src/components/chat-card/VariantChatCard.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ChatCard from './ChatCard';
+
+const meta = {
+  title: 'Components/ChatCard/Variants',
+  component: ChatCard,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ChatCard>;
+
+export default meta;
+type Story = StoryObj<typeof ChatCard>;
+
+export const BookClub: Story = {
+  args: {
+    variant: 'bookClub',
+    props: {
+      title: '을지로에서 만나는 독서 모임',
+      imageUrl: 'https://picsum.photos/200',
+      isHost: true,
+      currentParticipants: 17,
+      maxParticipants: 20,
+      lastMessage: '반갑습니다~!',
+      lastMessageTime: '10:29',
+      unreadCount: 3,
+    },
+  },
+};
+
+export const BookClubWithoutHost: Story = {
+  args: {
+    variant: 'bookClub',
+    props: {
+      title: '강남 독서 모임',
+      imageUrl: 'https://picsum.photos/200',
+      isHost: false,
+      currentParticipants: 8,
+      maxParticipants: 10,
+      lastMessage: '안녕하세요!',
+      lastMessageTime: '방금 전',
+      unreadCount: 1,
+    },
+  },
+};

--- a/src/components/chat-card/VariantChatCard.stories.tsx
+++ b/src/components/chat-card/VariantChatCard.stories.tsx
@@ -7,40 +7,80 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
+  argTypes: {
+    props: {
+      isHost: {
+        control: 'boolean',
+        description: '호스트 여부',
+      },
+    },
+  },
   tags: ['autodocs'],
 } satisfies Meta<typeof ChatCard>;
 
 export default meta;
 type Story = StoryObj<typeof ChatCard>;
 
-export const BookClub: Story = {
-  args: {
-    variant: 'bookClub',
-    props: {
-      title: '을지로에서 만나는 독서 모임',
-      imageUrl: 'https://picsum.photos/200',
-      isHost: true,
-      currentParticipants: 17,
-      maxParticipants: 20,
-      lastMessage: '반갑습니다~!',
-      lastMessageTime: '10:29',
-      unreadCount: 3,
-    },
+const baseArgs = {
+  variant: 'bookClub' as const,
+  props: {
+    title: '을지로에서 만나는 독서 모임',
+    imageUrl: 'https://picsum.photos/200',
+    isHost: true,
+    currentParticipants: 17,
+    lastMessage: '반갑습니다~!',
+    lastMessageTime: '10:29',
+    unreadCount: 3,
   },
 };
 
-export const BookClubWithoutHost: Story = {
-  args: {
-    variant: 'bookClub',
-    props: {
-      title: '강남 독서 모임',
-      imageUrl: 'https://picsum.photos/200',
-      isHost: false,
-      currentParticipants: 8,
-      maxParticipants: 10,
-      lastMessage: '안녕하세요!',
-      lastMessageTime: '방금 전',
-      unreadCount: 1,
+// 모바일 버전
+export const Mobile: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile',
     },
   },
+  decorators: [
+    (Story) => (
+      <div className="w-[342px]">
+        <Story />
+      </div>
+    ),
+  ],
+  args: baseArgs,
+};
+
+// 태블릿 버전
+export const Tablet: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'tablet',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[700px]">
+        <Story />
+      </div>
+    ),
+  ],
+  args: baseArgs,
+};
+
+// 데스크톱 버전
+export const Desktop: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[1000px]">
+        <Story />
+      </div>
+    ),
+  ],
+  args: baseArgs,
 };

--- a/src/components/chat-card/types/chatCard.ts
+++ b/src/components/chat-card/types/chatCard.ts
@@ -1,0 +1,39 @@
+export interface ChatCardProps extends React.HTMLAttributes<HTMLElement> {
+  children: React.ReactNode;
+}
+
+export interface ChatCardBoxProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+export interface ChatCardTitleProps
+  extends React.HTMLAttributes<HTMLHeadingElement> {
+  children: React.ReactNode;
+}
+
+export interface ChatCardImageProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
+  url: string;
+  alt?: string;
+}
+
+export interface ChatCardLocationProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+  textClassName?: string;
+}
+
+export interface ChatCardDateTimeProps
+  extends React.HTMLAttributes<HTMLSpanElement> {
+  children: React.ReactNode;
+}
+
+export interface ChatCardLastMessageProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+export interface ChatCardLastMessageTimeProps
+  extends React.HTMLAttributes<HTMLSpanElement> {
+  children: React.ReactNode;
+}

--- a/src/components/chat-card/types/chatCard.ts
+++ b/src/components/chat-card/types/chatCard.ts
@@ -4,6 +4,7 @@ export interface ChatCardProps extends React.HTMLAttributes<HTMLElement> {
 
 export interface ChatCardBoxProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
+  isHost?: boolean;
 }
 
 export interface ChatCardTitleProps
@@ -15,6 +16,7 @@ export interface ChatCardImageProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
   url: string;
   alt?: string;
+  isHost?: boolean;
 }
 
 export interface ChatCardLocationProps

--- a/src/components/chat-card/types/chatCard.ts
+++ b/src/components/chat-card/types/chatCard.ts
@@ -14,7 +14,7 @@ export interface ChatCardTitleProps
 
 export interface ChatCardImageProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
-  url: string;
+  url?: string | undefined;
   alt?: string;
   isHost?: boolean;
 }

--- a/src/components/chat-card/types/index.ts
+++ b/src/components/chat-card/types/index.ts
@@ -1,1 +1,2 @@
 export * from './chatCard';
+export * from './variantChatCard';

--- a/src/components/chat-card/types/index.ts
+++ b/src/components/chat-card/types/index.ts
@@ -1,0 +1,1 @@
+export * from './chatCard';

--- a/src/components/chat-card/types/variantChatCard.ts
+++ b/src/components/chat-card/types/variantChatCard.ts
@@ -1,6 +1,6 @@
-type ChatCardVariant = 'bookClub' | 'default';
+type ChatCardVariant = 'bookClub' | 'chatRoomHeader';
 
-interface BookClubProps {
+export interface BookClubProps {
   imageUrl?: string;
   isHost?: boolean;
   title: string;
@@ -11,8 +11,17 @@ interface BookClubProps {
   className?: string;
 }
 
+export interface ChatRoomHeaderProps {
+  imageUrl?: string;
+  isHost?: boolean;
+  title: string;
+  location: string;
+  datetime: string;
+  className?: string;
+}
+
 export interface ChatCardComponentProps
   extends React.HTMLAttributes<HTMLDivElement> {
   variant: ChatCardVariant;
-  props: BookClubProps; // 추후 다른 variant props를 union type으로 추가
+  props: BookClubProps | ChatRoomHeaderProps;
 }

--- a/src/components/chat-card/types/variantChatCard.ts
+++ b/src/components/chat-card/types/variantChatCard.ts
@@ -1,0 +1,18 @@
+type ChatCardVariant = 'bookClub' | 'default';
+
+interface BookClubProps {
+  imageUrl?: string;
+  isHost?: boolean;
+  title: string;
+  currentParticipants: number;
+  lastMessage?: string;
+  lastMessageTime?: string;
+  unreadCount?: number;
+  className?: string;
+}
+
+export interface ChatCardComponentProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  variant: ChatCardVariant;
+  props: BookClubProps; // 추후 다른 variant props를 union type으로 추가
+}

--- a/src/components/chat-card/types/variantChatCard.ts
+++ b/src/components/chat-card/types/variantChatCard.ts
@@ -4,6 +4,7 @@ interface CommonProps extends React.HTMLAttributes<HTMLDivElement> {
   title: string;
   imageUrl?: string;
   isHost?: boolean;
+  onClick?: () => void;
 }
 
 export interface BookClubProps extends CommonProps {

--- a/src/components/chat-card/types/variantChatCard.ts
+++ b/src/components/chat-card/types/variantChatCard.ts
@@ -1,27 +1,29 @@
-type ChatCardVariant = 'bookClub' | 'chatRoomHeader';
+export type ChatCardVariant = 'bookClub' | 'chatRoomHeader';
 
-export interface BookClubProps {
+interface CommonProps extends React.HTMLAttributes<HTMLDivElement> {
+  title: string;
   imageUrl?: string;
   isHost?: boolean;
-  title: string;
+}
+
+export interface BookClubProps extends CommonProps {
   currentParticipants: number;
   lastMessage?: string;
   lastMessageTime?: string;
   unreadCount?: number;
-  className?: string;
 }
 
-export interface ChatRoomHeaderProps {
-  imageUrl?: string;
-  isHost?: boolean;
-  title: string;
+export interface ChatRoomHeaderProps extends CommonProps {
   location: string;
   datetime: string;
-  className?: string;
 }
 
-export interface ChatCardComponentProps
-  extends React.HTMLAttributes<HTMLDivElement> {
-  variant: ChatCardVariant;
-  props: BookClubProps | ChatRoomHeaderProps;
+type ChatCardVariantProps = {
+  bookClub: BookClubProps;
+  chatRoomHeader: ChatRoomHeaderProps;
+};
+
+export interface ChatCardComponentProps<T extends ChatCardVariant> {
+  variant: T;
+  props: ChatCardVariantProps[T];
 }

--- a/src/components/participant-counter/ParticipantCounter.test.tsx
+++ b/src/components/participant-counter/ParticipantCounter.test.tsx
@@ -17,4 +17,10 @@ describe('ParticipantCounter', () => {
     render(<ParticipantCounter current={15} max={20} isPast={true} />);
     expect(screen.getByRole('participant-count')).toHaveTextContent('15/20');
   });
+
+  it('max 값이 없을 때 current만 표시되는지 확인', () => {
+    render(<ParticipantCounter current={15} />);
+    expect(screen.getByRole('participant-count')).toHaveTextContent('15');
+    expect(screen.getByRole('participant-count')).not.toHaveTextContent('/');
+  });
 });

--- a/src/components/participant-counter/ParticipantCounter.tsx
+++ b/src/components/participant-counter/ParticipantCounter.tsx
@@ -1,7 +1,7 @@
 interface ParticipantCounterProps
   extends React.ComponentPropsWithoutRef<'div'> {
   current: number;
-  max: number;
+  max?: number;
   isPast?: boolean;
 }
 
@@ -11,7 +11,7 @@ function ParticipantCounter({
   isPast = false,
   ...props
 }: ParticipantCounterProps) {
-  const isFull = current >= max;
+  const isFull = max ? current >= max : false;
   const primaryColor = isPast ? 'text-gray-dark-02' : 'text-green-normal-01';
   const maxColor = isFull ? primaryColor : 'text-gray-dark-01';
 
@@ -33,7 +33,7 @@ function ParticipantCounter({
         className="text-sm font-medium"
       >
         <span className={primaryColor}>{current}</span>
-        <span className={maxColor}>/{max}</span>
+        {max && <span className={maxColor}>/{max}</span>}
       </span>
     </div>
   );


### PR DESCRIPTION
<!--
1. 제목은 50자 이내
2. 장황하게 설명하지 않고 간단하게 기술
3. 과거 시제 사용 X
4. 명사형 어미 사용

* 제목양식
:emoji:[태그] 제목 #이슈번호
태그 첫 글자는 대문자로 작성
예시) ✨[Feat] 로그인 기능 구현 #32

* 제목 태그 종류
✨[Feat] 새로운 기능 추가
🐛[Fix] 버그 수정
📝[Docs] 문서 수정
🎨[Style] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
💄[Design] CSS 등 사용자 UI 디자인 변경
♻️[Refactor] 코드 리팩토링
✅[Test] 테스트 코드, 리팩토링 테스트 코드 추가
📦[Chore] 빌드 업무 수정, 패키지 매니저 수정
🚚[Rename] 파일 혹은 몰더명 수정하거나 옮기는 작업만 한 경우
🔥[Remove] 파일을 삭제하는 작업만 한 경우
💬[Comment] 필요한 주석 추가 및 변경


* 작성 후 이슈, 라벨, 마일스톤 등 연결해주세요.
* Assignees : 작업자
-->

## #️⃣연관된 이슈

> ex) #207, #206

## 📝작업 내용

> 채팅 카드 컴포넌트의 ui 구현

### 미리보기, 사용방법 및 결과물

채팅쪽에서 사용되는 카드들을 구현했습니다. 

`variant`는 2가지로 `bookClub` (채팅페이지로 입장시 보여질 카드) , `chatRoomHeader` (실제 채팅방 입장시 내부 상단에 놓여질 카드)

### `bookClubChatCard`
**모바일**
<img width="352" alt="image" src="https://github.com/user-attachments/assets/1f2a7056-974d-4fd5-98df-4c1d32e8df6c" />

**태블릿, 데스트톱**
<img width="735" alt="image" src="https://github.com/user-attachments/assets/db50ff9c-77f6-48d9-b198-bdc6ee6e2444" />

**사용 예시**
```tsx
<ChatCard
      variant="bookClub"
      props={{
        imageUrl: "https://example.com/image.jpg",
        isHost: true,
        title: "독서모임 제목",
        currentParticipants: 5,
        lastMessage: "안녕하세요!",
        lastMessageTime: "10:30",
        unreadCount: 3,
        onClick: () => console.log("채팅방 클릭"),
      }}
    />
```

----

### `chatRoomHeader`
**모바일**
<img width="362" alt="image" src="https://github.com/user-attachments/assets/90f92030-0351-453a-aac9-4b108e556dd9" />

**태블릿, 데스트톱**
<img width="725" alt="image" src="https://github.com/user-attachments/assets/43a60d2e-6e1e-4cd7-b7cf-9af4f0a9d367" />

**사용 예시**
```tsx
<ChatCard
      variant="chatRoomHeader"
      props={{
        imageUrl: "https://example.com/image.jpg",
        isHost: false,
        title: "독서모임 제목",
        location: "강남역",
        datetime: "12/25(월) 오후 2:00",
        onClick: () => console.log("헤더 클릭"),
      }}
    />
```
----

이전 카드와 비슷하게 `chat-card` 폴더 내부에 `types` 폴더가 존재하며 `chatCard.ts`는 컴파운드 패턴으로 사용된 내부 atoms들에 대한 타입이, `variantChatCard.ts`에는 variant에 따라 나눠진 두 종류의 카드에 대한 타입이 담겨있습니다.

공통 props를 base로 확장하여 두가지 variant에 대한 타입을 명시해두었으니 추후에 수정하시게되면 해당 파일에서 진행하시면 될 것 같습니다!

```tsx
// 공통 
interface CommonProps extends React.HTMLAttributes<HTMLDivElement> {
  title: string;
  imageUrl?: string;
  isHost?: boolean;
  onClick?: () => void;
}

export interface BookClubProps extends CommonProps {
  currentParticipants: number;
  lastMessage?: string;
  lastMessageTime?: string;
  unreadCount?: number;
}

export interface ChatRoomHeaderProps extends CommonProps {
  location: string;
  datetime: string;
}
```

<!-- 미리보기 파일 첨부와 함께 사용 방법 작성. 이미지, 동영상 등 작업 내용을 확인할 수 있는 파일 첨부 -->

<!-- ## 💬리뷰 요구사항(선택) - 보류(코드 리뷰를 진행한다면...)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

### 기타 참고사항

`bookClub` 타입의 경우 `unreadCount`라는 값이 있는데 빨간색 뱃지에 담길 읽지 않은 메시지 수를 의미합니다.
이부분은 백엔드에서 아마 메세지 배열 전체를 줄 수 있을 것 같아서 api명세가 나오면 수정될 수 있을 것 같아요!

<!-- 필요한 경우 작성해주세요 -->
