### PR TITLE
✨[Feat] api 수정 및 추가 사항 적용

### DIFF
--- a/src/api/book-club/react-query/customHooks.ts
+++ b/src/api/book-club/react-query/customHooks.ts
@@ -9,6 +9,7 @@ import {
 } from '../index';
 import { WriteReviewParams } from '../types';
 import { AxiosError } from 'axios';
+import { BookClub, BookClubParams } from '@/types/bookclubs';
 
 export function useBookClubCreateMutation() {
   const queryClient = useQueryClient();
@@ -102,15 +103,55 @@ export function useCancelBookClub() {
 export function useLikeBookClub() {
   const queryClient = useQueryClient();
 
-  return useMutation<void, AxiosError<{ message: string }>, number>({
+  return useMutation<
+    void,
+    AxiosError<{ message: string }>,
+    number,
+    { previousBookClubs?: any }
+  >({
     mutationFn: (id: number) => bookClubLikeAPI.like(id),
-    onSuccess: (_, id) => {
-      queryClient.invalidateQueries({
-        queryKey: bookClubs.list().queryKey,
-      });
-      queryClient.invalidateQueries({
-        queryKey: bookClubs.detail(id).queryKey,
-      });
+
+    onMutate: async (id) => {
+      const filters: BookClubParams = {
+        bookClubType: 'ALL',
+        meetingType: 'ALL',
+        order: 'DESC',
+        page: 1,
+        size: 10,
+        searchKeyword: '',
+      };
+
+      const queryKey = bookClubs.list(filters).queryKey;
+
+      // console.log('onMutate 쿼리 키:', queryKey);
+
+      // 기존 캐시 데이터 확인
+      const previousBookClubs = queryClient.getQueryData<{
+        bookClubs: BookClub[];
+      }>(queryKey);
+
+      // console.log('onMutate 이전 캐시 데이터:', previousBookClubs);
+
+      if (previousBookClubs) {
+        queryClient.setQueryData(queryKey, {
+          ...previousBookClubs,
+          bookClubs: previousBookClubs.bookClubs.map((club: any) =>
+            club.id === id ? { ...club, isLiked: true } : club,
+          ),
+        });
+      }
+
+      return { previousBookClubs };
+    },
+
+    onError: (_error, _id, context) => {
+      // 요청 실패 시 이전 상태 복구
+      if (context?.previousBookClubs) {
+        queryClient.setQueryData(
+          bookClubs.list().queryKey,
+          context.previousBookClubs,
+        );
+      }
     },
   });
 }

--- a/src/api/book-club/react-query/customHooks.ts
+++ b/src/api/book-club/react-query/customHooks.ts
@@ -91,6 +91,9 @@ export function useCancelBookClub() {
     mutationFn: (id: number) => bookClubMainAPI.cancel(id),
     onSuccess: () => {
       queryClient.invalidateQueries({
+        queryKey: bookClubs.list().queryKey,
+      });
+      queryClient.invalidateQueries({
         queryKey: bookClubs.my()._ctx.created().queryKey,
       });
       queryClient.invalidateQueries({

--- a/src/api/book-club/react-query/likeOptimisticUpdate.ts
+++ b/src/api/book-club/react-query/likeOptimisticUpdate.ts
@@ -1,0 +1,60 @@
+import { QueryClient } from '@tanstack/react-query';
+import { BookClub } from '@/types/bookclubs';
+import { bookClubs } from './queries';
+import { DEFAULT_FILTERS } from '@/lib/constants/filters';
+
+export const likeOnMutate = async (
+  queryClient: QueryClient,
+  id: number,
+  isLiked: boolean,
+) => {
+  const listQueryKey = bookClubs.list(DEFAULT_FILTERS).queryKey;
+  const detailQueryKey = bookClubs.detail(id).queryKey;
+
+  const previousBookClubs = queryClient.getQueryData<{
+    bookClubs: BookClub[];
+  }>(listQueryKey);
+
+  const previousDetail = queryClient.getQueryData<BookClub>(detailQueryKey);
+
+  // 목록 캐시 업데이트
+  if (previousBookClubs) {
+    queryClient.setQueryData(listQueryKey, {
+      ...previousBookClubs,
+      bookClubs: previousBookClubs.bookClubs.map((club) =>
+        club.id === id ? { ...club, isLiked } : club,
+      ),
+    });
+  }
+
+  // 상세 캐시 업데이트
+  if (previousDetail) {
+    queryClient.setQueryData(detailQueryKey, {
+      ...previousDetail,
+      isLiked,
+    });
+  }
+
+  return { previousBookClubs, previousDetail };
+};
+
+export const likeOnError = (
+  queryClient: QueryClient,
+  id: number,
+  context: {
+    previousBookClubs?: { bookClubs: BookClub[] };
+    previousDetail?: BookClub;
+  },
+) => {
+  const listQueryKey = bookClubs.list(DEFAULT_FILTERS).queryKey;
+  const detailQueryKey = bookClubs.detail(id).queryKey;
+
+  // 이전 상태 복구
+  if (context.previousBookClubs) {
+    queryClient.setQueryData(listQueryKey, context.previousBookClubs);
+  }
+
+  if (context.previousDetail) {
+    queryClient.setQueryData(detailQueryKey, context.previousDetail);
+  }
+};

--- a/src/components/common-layout/FilterBar.tsx
+++ b/src/components/common-layout/FilterBar.tsx
@@ -3,24 +3,14 @@ import {
   SearchSection,
   FilterSection,
 } from '@/components/common-layout';
-import { BookClub, BookClubParams } from '@/types/bookclubs';
-import { Dispatch, SetStateAction } from 'react';
+import { BookClubParams } from '@/types/bookclubs';
 
 interface FilterBarProps {
   filters: BookClubParams;
   handleFilterChange: (newFilter: Partial<BookClubParams>) => void;
-  bookClubs: BookClub[];
-  initialBookClubs: BookClub[];
-  setBookClubs: Dispatch<SetStateAction<BookClub[]>>;
 }
 
-function FilterBar({
-  filters,
-  handleFilterChange,
-  bookClubs,
-  initialBookClubs,
-  setBookClubs,
-}: FilterBarProps) {
+function FilterBar({ filters, handleFilterChange }: FilterBarProps) {
   return (
     <section className="flex w-full flex-col gap-y-3 px-[20px] pt-[20px] md:px-[24px] lg:px-[102px]">
       <CategoryTabs filters={filters} onFilterChange={handleFilterChange} />
@@ -30,12 +20,7 @@ function FilterBar({
           handleFilterChange({ searchKeyword: value })
         }
       />
-      <FilterSection
-        bookClubs={bookClubs}
-        initialBookClubs={initialBookClubs}
-        setBookClubs={setBookClubs}
-        onFilterChange={handleFilterChange}
-      />
+      <FilterSection onFilterChange={handleFilterChange} />
     </section>
   );
 }

--- a/src/components/common-layout/FilterSection.tsx
+++ b/src/components/common-layout/FilterSection.tsx
@@ -2,45 +2,23 @@
 
 import DropDown from '@/components/drop-down/DropDown';
 import FilterCheckbox from '@/components/filter-checkbox/FilterCheckbox';
-import { ChangeEvent, Dispatch, SetStateAction, useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 import SortingButton from '@/components/sorting-button/SortingButton';
-import { BookClub, BookClubParams } from '../../types/bookclubs';
+import { BookClubParams } from '../../types/bookclubs';
 import { getMeetingType, getMemberLimit } from '@/lib/utils/filterUtils';
-import { clubStatus } from '@/lib/utils/clubUtils';
 
 interface CategoryTabsProps {
-  bookClubs: BookClub[];
-  initialBookClubs: BookClub[];
-  setBookClubs: Dispatch<SetStateAction<BookClub[]>>;
   onFilterChange: (newFilters: Partial<BookClubParams>) => void;
 }
 
-function FilterSection({
-  bookClubs,
-  initialBookClubs,
-  setBookClubs,
-  onFilterChange,
-}: CategoryTabsProps) {
+function FilterSection({ onFilterChange }: CategoryTabsProps) {
   const [showAvailableOnly, setShowAvailableOnly] = useState(false); // 신청가능
 
   const toggleAvailableOnly = (e: ChangeEvent<HTMLInputElement>) => {
     const isChecked = e.target.checked;
     setShowAvailableOnly(isChecked);
 
-    const filteredBookClubs = isChecked
-      ? bookClubs.filter(
-          (club) =>
-            club.memberCount < club.memberLimit &&
-            clubStatus(
-              club.memberCount,
-              club.memberLimit,
-              club.endDate,
-              new Date(),
-            ) !== 'closed',
-        )
-      : initialBookClubs;
-
-    setBookClubs(filteredBookClubs);
+    onFilterChange({ isAvailable: isChecked });
   };
 
   const updateMemberLimitFilter = (selectedValue: string | undefined) => {

--- a/src/features/bookclub/components/BookClubMainPage.tsx
+++ b/src/features/bookclub/components/BookClubMainPage.tsx
@@ -9,14 +9,7 @@ import { useRouter } from 'next/navigation';
 import Loading from '@/components/loading/Loading';
 
 function BookClubMainPage() {
-  const {
-    clubList,
-    initialBookClubs,
-    setClubList,
-    isLoading,
-    filters,
-    updateFilters,
-  } = useBookClubList();
+  const { clubList, isLoading, filters, updateFilters } = useBookClubList();
 
   const router = useRouter();
 
@@ -48,13 +41,7 @@ function BookClubMainPage() {
           />
         }
       />
-      <FilterBar
-        filters={filters}
-        handleFilterChange={handleFilterChange}
-        bookClubs={clubList}
-        initialBookClubs={initialBookClubs}
-        setBookClubs={setClubList}
-      />
+      <FilterBar filters={filters} handleFilterChange={handleFilterChange} />
       {isLoading ? (
         <div className="flex h-[400px] justify-center">
           <Loading />

--- a/src/features/bookclub/hooks/useFetchBookClubList.ts
+++ b/src/features/bookclub/hooks/useFetchBookClubList.ts
@@ -2,17 +2,11 @@ import { useState } from 'react';
 import { BookClubParams } from '@/types/bookclubs';
 import { useQuery } from '@tanstack/react-query';
 import { bookClubs } from '@/api/book-club/react-query';
+import { DEFAULT_FILTERS } from '@/lib/constants/filters';
 // import { queryClient } from '@/lib/utils/reactQueryProvider';
 
 const useBookClubList = () => {
-  const [filters, setFilters] = useState<BookClubParams>({
-    bookClubType: 'ALL',
-    meetingType: 'ALL',
-    order: 'DESC',
-    page: 1,
-    size: 10,
-    searchKeyword: '',
-  });
+  const [filters, setFilters] = useState<BookClubParams>(DEFAULT_FILTERS);
 
   const { data, isLoading, error } = useQuery({
     ...bookClubs.list(filters),

--- a/src/features/bookclub/hooks/useFetchBookClubList.ts
+++ b/src/features/bookclub/hooks/useFetchBookClubList.ts
@@ -3,7 +3,6 @@ import { BookClubParams } from '@/types/bookclubs';
 import { useQuery } from '@tanstack/react-query';
 import { bookClubs } from '@/api/book-club/react-query';
 import { DEFAULT_FILTERS } from '@/lib/constants/filters';
-// import { queryClient } from '@/lib/utils/reactQueryProvider';
 
 const useBookClubList = () => {
   const [filters, setFilters] = useState<BookClubParams>(DEFAULT_FILTERS);
@@ -14,11 +13,7 @@ const useBookClubList = () => {
 
   const clubList = data?.bookClubs;
 
-  // console.log('쿼리 키:', bookClubs.list(filters).queryKey);
-  console.log('useQuery 데이터:', clubList);
-
-  //   const queryKey = bookClubs.list(filters).queryKey;
-  // console.log('캐시 데이터:', queryClient.getQueryData(queryKey));
+  // console.log('useQuery 데이터:', clubList);
 
   const updateFilters = (newFilters: Partial<BookClubParams>) => {
     setFilters((prevFilters) => ({ ...prevFilters, ...newFilters }));

--- a/src/features/bookclub/hooks/useFetchBookClubList.ts
+++ b/src/features/bookclub/hooks/useFetchBookClubList.ts
@@ -1,12 +1,9 @@
-import { useState, useEffect } from 'react';
-import { BookClub, BookClubParams } from '@/types/bookclubs';
+import { useState } from 'react';
+import { BookClubParams } from '@/types/bookclubs';
 import { useQuery } from '@tanstack/react-query';
 import { bookClubs } from '@/api/book-club/react-query';
 
 const useBookClubList = () => {
-  // TODO: 신청 가능 필터 param 추가시 clubList, initialBookClubs 상태 관리x
-  const [clubList, setClubList] = useState<BookClub[]>([]);
-  const [initialBookClubs, setInitialBookClubs] = useState<BookClub[]>([]);
   const [filters, setFilters] = useState<BookClubParams>({
     bookClubType: 'ALL',
     meetingType: 'ALL',
@@ -20,15 +17,9 @@ const useBookClubList = () => {
     ...bookClubs.list(filters),
   });
 
-  const clubInfo = data?.bookClubs;
+  const clubList = data?.bookClubs;
 
-  // TODO: param 추가시, useEffect 대신 clubInfo 직접 사용
-  useEffect(() => {
-    if (clubInfo) {
-      setClubList(clubInfo);
-      setInitialBookClubs(clubInfo); // 초기 데이터 설정
-    }
-  }, [clubInfo]);
+  console.log(clubList);
 
   const updateFilters = (newFilters: Partial<BookClubParams>) => {
     setFilters((prevFilters) => ({ ...prevFilters, ...newFilters }));
@@ -36,8 +27,6 @@ const useBookClubList = () => {
 
   return {
     clubList,
-    initialBookClubs,
-    setClubList,
     isLoading,
     error,
     filters,

--- a/src/features/bookclub/hooks/useFetchBookClubList.ts
+++ b/src/features/bookclub/hooks/useFetchBookClubList.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { BookClubParams } from '@/types/bookclubs';
 import { useQuery } from '@tanstack/react-query';
 import { bookClubs } from '@/api/book-club/react-query';
+// import { queryClient } from '@/lib/utils/reactQueryProvider';
 
 const useBookClubList = () => {
   const [filters, setFilters] = useState<BookClubParams>({
@@ -19,7 +20,11 @@ const useBookClubList = () => {
 
   const clubList = data?.bookClubs;
 
-  console.log(clubList);
+  // console.log('쿼리 키:', bookClubs.list(filters).queryKey);
+  console.log('useQuery 데이터:', clubList);
+
+  //   const queryKey = bookClubs.list(filters).queryKey;
+  // console.log('캐시 데이터:', queryClient.getQueryData(queryKey));
 
   const updateFilters = (newFilters: Partial<BookClubParams>) => {
     setFilters((prevFilters) => ({ ...prevFilters, ...newFilters }));

--- a/src/features/club-details/components/ReviewSummary.tsx
+++ b/src/features/club-details/components/ReviewSummary.tsx
@@ -7,6 +7,10 @@ import {
 } from '@/features/club-details/utils/rating';
 
 function ReviewSummary({ reviewInfo }: { reviewInfo: ClubReviewResponse }) {
+  const validAverageScore = isNaN(reviewInfo.averageScore)
+    ? 0
+    : reviewInfo.averageScore;
+
   return (
     <section>
       <h2 className="mb-[10px] text-[20px] font-semibold text-gray-black">
@@ -20,10 +24,10 @@ function ReviewSummary({ reviewInfo }: { reviewInfo: ClubReviewResponse }) {
       >
         <div className="flex flex-col items-center justify-center gap-2">
           <div className="text-2xl font-semibold">
-            <span className="text-gray-black">{reviewInfo.averageScore}</span>
+            <span className="text-gray-black">{validAverageScore}</span>
             <span className="text-gray-dark-01"> / 5</span>
           </div>
-          <RatingDisplay ratingCount={reviewInfo.averageScore} />
+          <RatingDisplay ratingCount={validAverageScore} />
         </div>
         <div className="flex flex-col gap-1">
           {[5, 4, 3, 2, 1].map((score) => (

--- a/src/features/club-wish/components/WishPage.tsx
+++ b/src/features/club-wish/components/WishPage.tsx
@@ -18,13 +18,7 @@ function WishPage() {
         }
       />
 
-      <FilterBar
-        filters={filters}
-        handleFilterChange={() => {}}
-        bookClubs={mockBookClubs}
-        setBookClubs={() => {}}
-        initialBookClubs={[]}
-      />
+      <FilterBar filters={filters} handleFilterChange={() => {}} />
       <ClubWishList bookClubs={mockBookClubs} />
     </>
   );

--- a/src/lib/constants/filters.ts
+++ b/src/lib/constants/filters.ts
@@ -1,0 +1,10 @@
+import { BookClubParams } from '@/types/bookclubs';
+
+export const DEFAULT_FILTERS: BookClubParams = {
+  bookClubType: 'ALL',
+  meetingType: 'ALL',
+  order: 'DESC',
+  page: 1,
+  size: 10,
+  searchKeyword: '',
+};

--- a/src/types/bookclubs.ts
+++ b/src/types/bookclubs.ts
@@ -10,6 +10,7 @@ export interface BookClubParams {
   searchKeyword?: string;
   memberLimitMin?: number;
   memberLimitMax?: number;
+  isAvailable?: boolean;
 }
 
 export interface MyProfileParams {


### PR DESCRIPTION
<!--
1. 제목은 50자 이내
2. 장황하게 설명하지 않고 간단하게 기술
3. 과거 시제 사용 X
4. 명사형 어미 사용

* 제목양식
:emoji:[태그] 제목 #이슈번호
태그 첫 글자는 대문자로 작성
예시) ✨[Feat] 로그인 기능 구현 #32

* 제목 태그 종류
✨[Feat] 새로운 기능 추가
🐛[Fix] 버그 수정
📝[Docs] 문서 수정
🎨[Style] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
💄[Design] CSS 등 사용자 UI 디자인 변경
♻️[Refactor] 코드 리팩토링
✅[Test] 테스트 코드, 리팩토링 테스트 코드 추가
📦[Chore] 빌드 업무 수정, 패키지 매니저 수정
🚚[Rename] 파일 혹은 몰더명 수정하거나 옮기는 작업만 한 경우
🔥[Remove] 파일을 삭제하는 작업만 한 경우
💬[Comment] 필요한 주석 추가 및 변경


* 작성 후 이슈, 라벨, 마일스톤 등 연결해주세요.
* Assignees : 작업자
-->

## #️⃣연관된 이슈

>#290 #291 #292

## 📝작업 내용

**모임 목록 조회 페이지**
- 신청 가능 필터 기존 로직 제거 및 api 사용
- 찜하기 딜레이 문제 확인 및 해결
    - 문제: #291
    - 해결: #292 

**모임 상세 페이지**
- 리뷰 평균이 NaN일 경우, 0으로 표시
- 주최자: 모임 취소하기 후 모임 목록 캐시 무효화

### 미리보기 및 결과물

찜하기 클릭 시 UI 즉각 적용

https://github.com/user-attachments/assets/3894f0ca-2bfb-4be9-b382-8f13727e0174

 ## 💬리뷰 요구사항

**낙관적 업데이트**를 사용하여 찜하기 UI 딜레이 문제를 해결했어요!

#### 문제 상황
찜하기 버튼을 클릭했을 때, 찜 상태가 즉시 반영되지 않고 두 번 클릭해야 상태가 반영됨.

#### 원인 분석
1. 찜하기 요청 → 서버 데이터 변경 (시간 소요)
2. `invalidateQueries` 호출 → 캐시 무효화 → 서버에서 데이터 다시 가져옴 (추가 시간 소요)
3. UI가 새 데이터를 반영 (최종적으로 변경됨)

즉, 두 번 클릭이 필요했던 이유는 **`invalidateQueries`로 캐시를 무효화한 후 네트워크 요청이 완료되기까지 시간이 걸리기 때문**입니다.

#### 해결
1. 낙관적 업데이트를 적용하여 UI와 캐시가 먼저 업데이트하고, 네트워크 요청의 결과를 기다리지 않고 즉시 반영합니다.
2. `invalidateQueries`는 캐시 무효화를 초래하여 UI와 데이터 동기화에 텀을 유발하므로 제거합니다.

> 관련 상세 내용은 위의 해결 이슈를 참고해주세요!

찜하기를 클릭했을 때 UI가 바로 반영되고 있습니다만... 로직이 맞는지는 확신이 없네요...ㅎㅎ

### 기타 참고사항

#### **낙관적 업데이트(Optimistic Update)란?**

낙관적 업데이트는 사용자가 요청을 보냈을 때, **서버 응답을 기다리지 않고 UI를 먼저 업데이트**하는 방법이다.
사용자가 보는 화면을 즉각적으로 반영함으로써 더 빠르고 부드러운 사용자 경험(UX)을 제공한다.

#### 💡 **주요 동작 과정**
1. **요청 전에 UI를 업데이트**
    요청이 성공할 것이라고 가정(낙관적으로 생각)하고 UI 상태를 변경한다.
2. **요청 실패 시 복원**
    요청이 실패하면 이전 상태로 돌아가도록 데이터를 복구한다.
3. **요청 성공 시 캐시 갱신**
    서버에서 최신 데이터를 받아 캐시를 업데이트한다.