### PR TITLE
♻️ [Refactor] 프로그레스바 넘침 현상 해결

### DIFF
--- a/src/components/progress-bar/ProgressBar.test.tsx
+++ b/src/components/progress-bar/ProgressBar.test.tsx
@@ -16,4 +16,13 @@ describe('ProgressBar', () => {
     const fillBar = screen.getByRole('progressbar').children[0];
     expect(fillBar).toHaveStyle({ width: '25%' });
   });
+
+  it('percentage가 100을 초과할 경우 100%로 제한되는지 확인', () => {
+    render(<ProgressBar percentage={150} />);
+    const progressbar = screen.getByRole('progressbar');
+    const fillBar = progressbar.children[0];
+
+    expect(progressbar).toHaveAttribute('aria-valuenow', '100');
+    expect(fillBar).toHaveStyle({ width: '100%' });
+  });
 });

--- a/src/components/progress-bar/ProgressBar.tsx
+++ b/src/components/progress-bar/ProgressBar.tsx
@@ -16,10 +16,12 @@ function ProgressBar({
   const fillColor =
     color || (isPast ? 'bg-gray-dark-02' : 'bg-green-normal-01');
 
+  const limitedPercentage = Math.min(100, Math.max(0, percentage));
+
   return (
     <div
       role="progressbar"
-      aria-valuenow={percentage}
+      aria-valuenow={limitedPercentage}
       aria-valuemin={0}
       aria-valuemax={100}
       className={`h-1 w-full rounded-md bg-gray-normal-01 ${className || ''}`}
@@ -28,7 +30,7 @@ function ProgressBar({
       <div
         className={`h-full rounded-md transition-all duration-300 ${fillColor}`}
         style={{
-          width: `${percentage}%`,
+          width: `${limitedPercentage}%`,
         }}
       />
     </div>


### PR DESCRIPTION
<!--
1. 제목은 50자 이내
2. 장황하게 설명하지 않고 간단하게 기술
3. 과거 시제 사용 X
4. 명사형 어미 사용

* 제목양식
:emoji:[태그] 제목 #이슈번호
태그 첫 글자는 대문자로 작성
예시) ✨[Feat] 로그인 기능 구현 #32

* 제목 태그 종류
✨[Feat] 새로운 기능 추가
🐛[Fix] 버그 수정
📝[Docs] 문서 수정
🎨[Style] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
💄[Design] CSS 등 사용자 UI 디자인 변경
♻️[Refactor] 코드 리팩토링
✅[Test] 테스트 코드, 리팩토링 테스트 코드 추가
📦[Chore] 빌드 업무 수정, 패키지 매니저 수정
🚚[Rename] 파일 혹은 몰더명 수정하거나 옮기는 작업만 한 경우
🔥[Remove] 파일을 삭제하는 작업만 한 경우
💬[Comment] 필요한 주석 추가 및 변경


* 작성 후 이슈, 라벨, 마일스톤 등 연결해주세요.
* Assignees : 작업자
-->

## #️⃣연관된 이슈

> ex) #310 

## 📝작업 내용

> 프로그레스바의 넘침 현상을 해결



### 기타 참고사항

프로그레스바에서 `percentage` 가 100이상으로 들어올 경우 처리를 해두긴했지만 애초에 이런 경우가 들어오지 않도록,
**프론트에서는 '정원 = 참여자 수' 일 경우 더 이상 참여를 못하도록,
백엔드에서도 이런 경우 요청이 오면 에러를 내도록** 추가 처리가 필요할 것 같습니다. 
