### PR TITLE
✨[Feat] 모임 찾기 페이지 비로그인 찜 클릭 시 로그인 안내창 추가 #336

### DIFF
--- a/src/features/club-details/components/HeaderSection.tsx
+++ b/src/features/club-details/components/HeaderSection.tsx
@@ -13,6 +13,7 @@ import { useJoinClub } from '../hooks';
 import {
   useCancelClub,
   useLeaveClub,
+  useLikeClub,
   useLikeWithAuthCheck,
   useUnLikeClub,
 } from '@/lib/hooks/index';
@@ -42,9 +43,10 @@ function HeaderSection({ clubInfo, idAsNumber }: HeaderSectionProps) {
   const {
     isLikePopUpOpen,
     likePopUpLabel,
-    onCheckAuthPopUp,
+    onShowAuthPopUp,
     onCloseCheckAuthPopup,
   } = useLikeWithAuthCheck();
+  const { onConfirmLike } = useLikeClub();
   const { onConfirmUnLike } = useUnLikeClub();
 
   const { isLoggedIn, checkLoginStatus, user } = useAuthStore();
@@ -76,10 +78,16 @@ function HeaderSection({ clubInfo, idAsNumber }: HeaderSectionProps) {
     handleJoin(clubInfo.id);
   };
 
-  const handleLikeClub = () => {
-    clubInfo.isLiked
-      ? onConfirmUnLike(clubInfo.id)
-      : onCheckAuthPopUp(clubInfo.id);
+  const handleLikeClub = (isLiked: boolean) => {
+    if (!isLoggedIn) {
+      onShowAuthPopUp();
+      return;
+    }
+    if (isLiked) {
+      onConfirmUnLike(clubInfo.id);
+    } else {
+      onConfirmLike(clubInfo.id);
+    }
   };
 
   const handleLikePopUpConfirm = () => {
@@ -106,7 +114,7 @@ function HeaderSection({ clubInfo, idAsNumber }: HeaderSectionProps) {
       clubInfo.endDate,
       new Date(), // TODO: new Date() 최적화 후 수정
     ),
-    onLikeClick: handleLikeClub,
+    onLikeClick: () => handleLikeClub(clubInfo.isLiked),
     host: {
       id: clubInfo.hostId,
       name: clubInfo.hostNickname,

--- a/src/lib/hooks/useLikeWithAuthCheck.ts
+++ b/src/lib/hooks/useLikeWithAuthCheck.ts
@@ -1,27 +1,14 @@
-import { useEffect, useState } from 'react';
-import { useLikeClub } from './useLikeClub';
-import { useAuthStore } from '@/store/authStore';
+import { useState } from 'react';
 
 export const useLikeWithAuthCheck = () => {
-  const { onConfirmLike } = useLikeClub();
   const [isPopUpOpen, setIsPopUpOpen] = useState(false);
   const [popUpLabel, setPopUpLabel] = useState('');
 
-  const { isLoggedIn, checkLoginStatus } = useAuthStore();
-
-  useEffect(() => {
-    checkLoginStatus();
-  }, [checkLoginStatus]);
-
-  const onCheckAuthPopUp = (clubId: number) => {
-    if (isLoggedIn) {
-      onConfirmLike(clubId);
-    } else {
-      setPopUpLabel(
-        `로그인 후 이용할 수 있어요.\n로그인 페이지로 이동하시겠어요?`,
-      );
-      setIsPopUpOpen(true);
-    }
+  const onShowAuthPopUp = () => {
+    setPopUpLabel(
+      `로그인 후 이용할 수 있어요.\n로그인 페이지로 이동하시겠어요?`,
+    );
+    setIsPopUpOpen(true);
   };
 
   const onCloseCheckAuthPopup = () => {
@@ -32,7 +19,7 @@ export const useLikeWithAuthCheck = () => {
   return {
     isLikePopUpOpen: isPopUpOpen,
     likePopUpLabel: popUpLabel,
-    onCheckAuthPopUp,
+    onShowAuthPopUp,
     onCloseCheckAuthPopup,
   };
 };


### PR DESCRIPTION
<!--
1. 제목은 50자 이내
2. 장황하게 설명하지 않고 간단하게 기술
3. 과거 시제 사용 X
4. 명사형 어미 사용

* 제목양식
:emoji:[태그] 제목 #이슈번호
태그 첫 글자는 대문자로 작성
예시) ✨[Feat] 로그인 기능 구현 #32

* 제목 태그 종류
✨[Feat] 새로운 기능 추가
🐛[Fix] 버그 수정
📝[Docs] 문서 수정
🎨[Style] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
💄[Design] CSS 등 사용자 UI 디자인 변경
♻️[Refactor] 코드 리팩토링
✅[Test] 테스트 코드, 리팩토링 테스트 코드 추가
📦[Chore] 빌드 업무 수정, 패키지 매니저 수정
🚚[Rename] 파일 혹은 몰더명 수정하거나 옮기는 작업만 한 경우
🔥[Remove] 파일을 삭제하는 작업만 한 경우
💬[Comment] 필요한 주석 추가 및 변경


* 작성 후 이슈, 라벨, 마일스톤 등 연결해주세요.
* Assignees : 작업자
-->


## #️⃣연관된 이슈

> #336

## 📝작업 내용

- 모임 찾기 페이지에서 비 로그인 상태에서 찜 클릭 시 로그인 안내창 띄우기

 ### 미리보기 및 결과물

![image](https://github.com/user-attachments/assets/1e1f79ce-3022-4107-8772-9e38009cca5b)

<!-- ## 💬리뷰 요구사항(선택) - 보류(코드 리뷰를 진행한다면...)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

### 기타 참고사항

찜하기 관련 오류 미해결에 대한 임시 방편으로 비 로그인 유저가 찜하기를 클릭했을 때 로그인 안내창을 띄우는 로직을 추가하였습니다.